### PR TITLE
Fixed overlapping issues occuring with BTKSA mod when QMStats are set to always show

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -20,10 +20,10 @@ namespace NameplateStats
 
         private IEnumerator WaitForUiManager()
         {
-            while (VRCUiManager.field_Private_Static_VRCUiManager_0 == null) yield return new UnityEngine.WaitForSeconds(1);
-            while (Object.FindObjectOfType<VRC.UI.Elements.QuickMenu>() == null) yield return new UnityEngine.WaitForSeconds(0.5);
+            while (VRCUiManager.field_Private_Static_VRCUiManager_0 == null) yield return new UnityEngine.WaitForSeconds(1f);
+            while (Object.FindObjectOfType<VRC.UI.Elements.QuickMenu>() == null) yield return new UnityEngine.WaitForSeconds(0.5f);
             Nameplate.Start();
-            if(Prefs.IsBTKSANameplateModPresent) Prefs.OnLateStart();
+            Prefs.OnLateStart();
         }
         
         public override void OnSceneWasLoaded(int buildIndex, string sceneName)

--- a/Prefs.cs
+++ b/Prefs.cs
@@ -42,22 +42,25 @@
         private static bool? isCompanionPresent = false;
         public static void OnLateStart()
         {
-            if (!IsBTKSANameplateModPresent) return;
-            if (isCompanionPresent!.Value)
+            //if (!IsBTKSANameplateModPresent) return; //if we return here, static fields "isNameplateFixSAPresent" and "isCompanionPresent" will never be set to null
+            if (IsBTKSANameplateModPresent)
             {
-                _IsAlwaysShowQuickInfoOn = MelonPreferences.GetCategory("BTKCompanionNP")
-                    .GetEntry<bool>("nmAlwaysShowQuickInfo");
-            }
-            else if (isNameplateFixSAPresent!.Value)
-            {
-                _IsAlwaysShowQuickInfoOn = MelonPreferences.GetCategory("BTKSANameplateFix")
-                    .GetEntry<bool>("nmAlwaysShowQuickInfo");
+                if (isCompanionPresent == true)
+                {
+                    _IsAlwaysShowQuickInfoOn = MelonPreferences.GetCategory("BTKCompanionNP")
+                        .GetEntry<bool>("nmAlwaysShowQuickInfo");
+                }
+                else if (isNameplateFixSAPresent == true)
+                {
+                    _IsAlwaysShowQuickInfoOn = MelonPreferences.GetCategory("BTKSANameplateFix")
+                        .GetEntry<bool>("nmAlwaysShowQuickInfo");
+                }
+                Managers.NameplateStatsManager.AlwaysShowQuickMenuStats = _IsAlwaysShowQuickInfoOn.Value;
+                _IsAlwaysShowQuickInfoOn.OnValueChanged +=
+                (oldVal, newVal) => Managers.NameplateStatsManager.AlwaysShowQuickMenuStats = newVal;
             }
             isNameplateFixSAPresent = null;
             isCompanionPresent = null; // Yeeted out since we don't need this lurking in memory.
-
-            _IsAlwaysShowQuickInfoOn.OnValueChanged +=
-                (_, b1) => Managers.NameplateStatsManager.AlwaysShowQuickMenuStats = b1;
         }
 
         public static void ToggleEnable(bool enable)

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using MelonLoader;
 
 [assembly: MelonGame("VRChat","VRChat")]
-[assembly: MelonInfo(typeof(NameplateStats.Main),"NameplateStats","1.0.9","Yato#4499 + Dawn","https://www.github.com/Kiokuu/NameplateStats")]
+[assembly: MelonInfo(typeof(NameplateStats.Main),"NameplateStats","1.0.10","Yato#4499 + Dawn","https://www.github.com/Kiokuu/NameplateStats")]
 [assembly: MelonColor(ConsoleColor.DarkCyan)]
 [assembly: MelonPriority(62)]
 


### PR DESCRIPTION
vary lazy fix with close to no cleanup whatsoever
Changes:
- fixed "AlwaysShowQuickMenuStats" not being initialized with correct value, causing overlapping issues if BTKSA preference is left untouched
- version bump
don't forget to add 0Harmony.dll reference to the project, since harmony got it's own dll located in VRChat\MelonLoader\ with ml v0.5.4